### PR TITLE
優化 rfid 頁面 UI

### DIFF
--- a/src/pages/rfid_converter.js
+++ b/src/pages/rfid_converter.js
@@ -92,7 +92,7 @@ const RfidConverterPage = () => {
     <div className="bg-iosbgblue">
       <AppHeader title="iOS Club - RFID 轉換器" />
       <Navbar />
-      <div className="container mx-auto break-normal bg-white shadow-lg px-3 md:px-0 font-serif">
+      <div className="container mx-auto break-normal bg-white shadow-lg px-3 md:px-0 font-mono">
         <div className="h-20 md:h-32" />
 
         {/* 頁面標題 */}

--- a/src/pages/rfid_converter.js
+++ b/src/pages/rfid_converter.js
@@ -111,7 +111,10 @@ const RfidConverterPage = () => {
         <div className="max-w-4xl mx-auto pb-16">
           {/* 16進制轉10進制 */}
           <div className="relative bg-white rounded-xl p-6 md:p-8 mb-8 border border-gray-300 shadow-lg">
-            <span className="absolute left-0 top-0 bottom-0 w-1 bg-btnbg rounded-l-xl" aria-hidden="true"></span>
+            <span
+              className="absolute left-0 top-0 bottom-0 w-1 bg-btnbg rounded-l-xl"
+              aria-hidden="true"
+            ></span>
             <h3 className="text-xl font-bold text-gray-800 mb-6 flex items-center gap-2">
               <Icon icon="mdi:numeric-1-box" className="text-btnbg" />
               16進制轉10進制（支援位元組反轉）
@@ -174,7 +177,10 @@ const RfidConverterPage = () => {
 
           {/* 10進制轉16進制 */}
           <div className="relative bg-white rounded-xl p-6 md:p-8 mb-8 border border-gray-300 shadow-lg">
-            <span className="absolute left-0 top-0 bottom-0 w-1 bg-btnbg rounded-l-xl" aria-hidden="true"></span>
+            <span
+              className="absolute left-0 top-0 bottom-0 w-1 bg-btnbg rounded-l-xl"
+              aria-hidden="true"
+            ></span>
             <h3 className="text-xl font-bold text-gray-800 mb-6 flex items-center gap-2">
               <Icon icon="mdi:numeric-2-box" className="text-btnbg" />
               10進制轉16進制（支援位元組反轉）
@@ -239,7 +245,10 @@ const RfidConverterPage = () => {
 
           {/* 轉換範例 */}
           <div className="relative bg-white rounded-xl p-6 md:p-8 mb-8 border border-gray-300 shadow-lg">
-            <span className="absolute left-0 top-0 bottom-0 w-1 bg-btnbg rounded-l-xl" aria-hidden="true"></span>
+            <span
+              className="absolute left-0 top-0 bottom-0 w-1 bg-btnbg rounded-l-xl"
+              aria-hidden="true"
+            ></span>
             <h4 className="text-lg font-bold text-gray-800 mb-4 flex items-center gap-2">
               <Icon icon="mdi:lightbulb-on" className="text-btnbg" />
               轉換範例
@@ -260,7 +269,10 @@ const RfidConverterPage = () => {
 
           {/* 轉換原理 */}
           <div className="relative bg-white rounded-xl p-6 md:p-8 border border-gray-300 shadow-lg">
-            <span className="absolute left-0 top-0 bottom-0 w-1 bg-btnbg rounded-l-xl" aria-hidden="true"></span>
+            <span
+              className="absolute left-0 top-0 bottom-0 w-1 bg-btnbg rounded-l-xl"
+              aria-hidden="true"
+            ></span>
             <h4 className="text-lg font-bold text-gray-800 mb-4 flex items-center gap-2">
               <Icon icon="mdi:cog" className="text-btnbg" />
               轉換原理

--- a/src/pages/rfid_converter.js
+++ b/src/pages/rfid_converter.js
@@ -90,7 +90,7 @@ const RfidConverterPage = () => {
 
   return (
     <div className="bg-iosbgblue">
-      <AppHeader />
+      <AppHeader title="iOS Club - RFID 轉換器" />
       <Navbar />
       <div className="container mx-auto break-normal bg-white shadow-lg px-3 md:px-0 font-serif">
         <div className="h-20 md:h-32" />
@@ -99,7 +99,7 @@ const RfidConverterPage = () => {
         <div className="text-center py-12">
           <div className="flex justify-center items-center gap-3 mb-4">
             <Icon icon="mdi:rfid" className="text-4xl text-btnbg" />
-            <h1 className="text-4xl md:text-5xl font-bold text-gray-800">
+            <h1 className="text-5xl font-bold text-gray-800">
               RFID 卡號轉換器
             </h1>
           </div>
@@ -110,9 +110,10 @@ const RfidConverterPage = () => {
 
         <div className="max-w-4xl mx-auto pb-16">
           {/* 16進制轉10進制 */}
-          <div className="bg-gray-50 rounded-xl p-6 md:p-8 mb-8 border-l-4 border-blue-500">
+          <div className="relative bg-white rounded-xl p-6 md:p-8 mb-8 border border-gray-300 shadow-lg">
+            <span className="absolute left-0 top-0 bottom-0 w-1 bg-btnbg rounded-l-xl" aria-hidden="true"></span>
             <h3 className="text-xl font-bold text-gray-800 mb-6 flex items-center gap-2">
-              <Icon icon="mdi:numeric-1-box" className="text-blue-500" />
+              <Icon icon="mdi:numeric-1-box" className="text-btnbg" />
               16進制轉10進制（支援位元組反轉）
             </h3>
 
@@ -126,11 +127,11 @@ const RfidConverterPage = () => {
                   value={hexInput}
                   onChange={(e) => setHexInput(e.target.value)}
                   placeholder="請輸入16進制卡號..."
-                  className="flex-1 px-4 py-3 border-2 border-gray-300 rounded-lg font-mono text-lg focus:border-blue-500 focus:outline-none transition-colors"
+                  className="flex-1 px-4 py-3 border-2 border-gray-300 rounded-lg font-mono text-lg focus:border-btnbg focus:outline-none transition-colors"
                 />
                 <button
                   onClick={clearHex}
-                  className="px-4 py-3 bg-red-500 hover:bg-red-600 text-white rounded-lg transition-colors flex items-center justify-center"
+                  className="px-4 py-3 border border-gray-400 text-gray-700 rounded-lg hover:bg-btnbg hover:text-white transition-colors flex items-center justify-center"
                   title="清除輸入"
                 >
                   <Icon icon="mdi:close" className="text-xl" />
@@ -145,8 +146,8 @@ const RfidConverterPage = () => {
               <div
                 className={`p-4 rounded-lg border-2 font-mono ${
                   hexResult
-                    ? "bg-green-50 border-green-300 text-green-800"
-                    : "bg-gray-100 border-gray-300 text-gray-600"
+                    ? "bg-white border-btnbg text-gray-800"
+                    : "bg-white border-gray-300 text-gray-600"
                 }`}
               >
                 {!hexInput && "等待輸入..."}
@@ -172,9 +173,10 @@ const RfidConverterPage = () => {
           </div>
 
           {/* 10進制轉16進制 */}
-          <div className="bg-gray-50 rounded-xl p-6 md:p-8 mb-8 border-l-4 border-green-500">
+          <div className="relative bg-white rounded-xl p-6 md:p-8 mb-8 border border-gray-300 shadow-lg">
+            <span className="absolute left-0 top-0 bottom-0 w-1 bg-btnbg rounded-l-xl" aria-hidden="true"></span>
             <h3 className="text-xl font-bold text-gray-800 mb-6 flex items-center gap-2">
-              <Icon icon="mdi:numeric-2-box" className="text-green-500" />
+              <Icon icon="mdi:numeric-2-box" className="text-btnbg" />
               10進制轉16進制（支援位元組反轉）
             </h3>
 
@@ -188,11 +190,11 @@ const RfidConverterPage = () => {
                   value={decInput}
                   onChange={(e) => setDecInput(e.target.value)}
                   placeholder="請輸入10進制卡號..."
-                  className="flex-1 px-4 py-3 border-2 border-gray-300 rounded-lg font-mono text-lg focus:border-green-500 focus:outline-none transition-colors"
+                  className="flex-1 px-4 py-3 border-2 border-gray-300 rounded-lg font-mono text-lg focus:border-btnbg focus:outline-none transition-colors"
                 />
                 <button
                   onClick={clearDec}
-                  className="px-4 py-3 bg-red-500 hover:bg-red-600 text-white rounded-lg transition-colors flex items-center justify-center"
+                  className="px-4 py-3 border border-gray-400 text-gray-700 rounded-lg hover:bg-btnbg hover:text-white transition-colors flex items-center justify-center"
                   title="清除輸入"
                 >
                   <Icon icon="mdi:close" className="text-xl" />
@@ -207,8 +209,8 @@ const RfidConverterPage = () => {
               <div
                 className={`p-4 rounded-lg border-2 font-mono ${
                   decResult
-                    ? "bg-green-50 border-green-300 text-green-800"
-                    : "bg-gray-100 border-gray-300 text-gray-600"
+                    ? "bg-white border-btnbg text-gray-800"
+                    : "bg-white border-gray-300 text-gray-600"
                 }`}
               >
                 {!decInput && "等待輸入..."}
@@ -236,12 +238,13 @@ const RfidConverterPage = () => {
           </div>
 
           {/* 轉換範例 */}
-          <div className="bg-amber-50 border-l-4 border-amber-500 rounded-xl p-6 md:p-8 mb-8">
-            <h4 className="text-lg font-bold text-amber-800 mb-4 flex items-center gap-2">
-              <Icon icon="mdi:lightbulb-on" className="text-amber-500" />
+          <div className="relative bg-white rounded-xl p-6 md:p-8 mb-8 border border-gray-300 shadow-lg">
+            <span className="absolute left-0 top-0 bottom-0 w-1 bg-btnbg rounded-l-xl" aria-hidden="true"></span>
+            <h4 className="text-lg font-bold text-gray-800 mb-4 flex items-center gap-2">
+              <Icon icon="mdi:lightbulb-on" className="text-btnbg" />
               轉換範例
             </h4>
-            <div className="space-y-2 text-amber-800">
+            <div className="space-y-2 text-gray-800">
               <div>
                 <strong>軟體顯示：</strong>B4C5D677 (0xB4C5D677) →{" "}
                 <strong>反轉後：</strong>77D6C5B4 → <strong>10進制：</strong>
@@ -256,32 +259,33 @@ const RfidConverterPage = () => {
           </div>
 
           {/* 轉換原理 */}
-          <div className="bg-blue-50 border-l-4 border-blue-500 rounded-xl p-6 md:p-8">
-            <h4 className="text-lg font-bold text-blue-800 mb-4 flex items-center gap-2">
-              <Icon icon="mdi:cog" className="text-blue-500" />
+          <div className="relative bg-white rounded-xl p-6 md:p-8 border border-gray-300 shadow-lg">
+            <span className="absolute left-0 top-0 bottom-0 w-1 bg-btnbg rounded-l-xl" aria-hidden="true"></span>
+            <h4 className="text-lg font-bold text-gray-800 mb-4 flex items-center gap-2">
+              <Icon icon="mdi:cog" className="text-btnbg" />
               轉換原理
             </h4>
-            <div className="space-y-3 text-blue-800">
+            <div className="space-y-3 text-gray-800">
               <div className="flex items-start gap-2">
-                <span className="bg-blue-200 text-blue-800 text-sm px-2 py-1 rounded font-mono">
+                <span className="bg-btnbg text-white text-sm px-2 py-1 rounded font-mono">
                   1
                 </span>
                 <span>RFID卡片以小端序（Little Endian）儲存數據</span>
               </div>
               <div className="flex items-start gap-2">
-                <span className="bg-blue-200 text-blue-800 text-sm px-2 py-1 rounded font-mono">
+                <span className="bg-btnbg text-white text-sm px-2 py-1 rounded font-mono">
                   2
                 </span>
                 <span>軟體直接讀取顯示：B4 C5 D6 77</span>
               </div>
               <div className="flex items-start gap-2">
-                <span className="bg-blue-200 text-blue-800 text-sm px-2 py-1 rounded font-mono">
+                <span className="bg-btnbg text-white text-sm px-2 py-1 rounded font-mono">
                   3
                 </span>
                 <span>反轉位元組順序：77 D6 C5 B4</span>
               </div>
               <div className="flex items-start gap-2">
-                <span className="bg-blue-200 text-blue-800 text-sm px-2 py-1 rounded font-mono">
+                <span className="bg-btnbg text-white text-sm px-2 py-1 rounded font-mono">
                   4
                 </span>
                 <span>轉換為10進制：2010883508</span>


### PR DESCRIPTION
已完成 RfidConverterPage 的品牌一致化樣式優化，僅調整樣式與結構，不變更任何運算邏輯。

主要變更
- 加入頁面標題
  - 使用 [AppHeader](src/components/header.js) 於 [src/pages/rfid_converter.js](src/pages/rfid_converter.js) 傳入 title「iOS Club - RFID 轉換器」
- 主色一致化
  - 圖示與重點色統一使用主題色 text-btnbg（同步於章節標題）
  - 輸入框 focus 邊框改為 focus:border-btnbg
- 卡片風格統一
  - 16→10、10→16、轉換範例、轉換原理四個區塊改為「白底 + 灰邊框 + 陰影」：bg-white border border-gray-300 shadow-lg rounded-xl
  - 左側強調線以絕對定位細線呈現，使用 bg-btnbg 以符合主色
- 清除按鈕風格
  - 由紅底改為描邊按鈕：border border-gray-400 text-gray-700 hover:bg-btnbg hover:text-white，維持 Icon-only 尺寸
- 結果顯示統一
  - 改為 bg-white，僅用邊框與字色區分狀態：有效=border-btnbg text-gray-800；待輸入/無效=border-gray-300 text-gray-600
- 色票清理
  - 移除 text-green-*/bg-amber-50/bg-blue-50 等不一致色票，改為主色與中性色
- 版面一致
  - 頁面主標題字級統一至 text-5xl，維持全站 font-serif 與原有間距

涉及檔案
- [src/pages/rfid_converter.js](src/pages/rfid_converter.js)

驗收建議
- 於開發/部署環境開啟 /rfid_converter，檢視桌機與行動版：
  - 卡片均為白底+陰影+灰邊框，左側主色強調線正確
  - 兩個輸入框 focus 邊框顏色為主色 btnbg
  - 清除按鈕 hover 時背景為主色、字白
  - 結果框在有/無結果時邊框顏色如預期
  - 圖示使用主色、標題字級與其他頁一致

本次調整已完成「品牌一致方案」目標，使 RfidConverterPage 與全站樣式一致。

---


已在本頁面啟用等寬字體。調整方式：
- 將白底主內容容器字體從 serif 改為等寬字體，在 [div 容器 className 切換為 font-mono](src/pages/rfid_converter.js:95)
- Header/Navbar/Footer 未受影響（仍依各自樣式），頁面主體（含輸入框、結果區塊、說明文字）改為等寬顯示，與既有的 [font-mono input/result](src/pages/rfid_converter.js:130) 樣式一致
- 元件與運算邏輯未改動

若未來希望僅特定區域使用等寬字體，可把容器還原為 font-serif，並在需要的區塊內添加 font-mono 即可。當前版本符合「本頁面使用等寬字體」需求。