### PR TITLE
feat: 新增 IconPreloader 組件以預加載常用圖示，優化應用啟動性能

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,1 +1,61 @@
 import "./src/styles/global.css";
+import React from "react";
+import { Icon } from "@iconify/react";
+
+// Preload the most-used icons across the site to avoid first-paint delays.
+// Rendering them invisibly will trigger Iconify to fetch and cache the data early.
+const preloadIcons = [
+  // ant-design
+  "ant-design:caret-left-outlined",
+  "ant-design:caret-right-outlined",
+
+  // logos
+  "logos:youtube-icon",
+
+  // akar-icons
+  "akar-icons:triangle-fill",
+  "akar-icons:calendar",
+  "akar-icons:more-vertical-fill",
+  "akar-icons:cross",
+
+  // mdi
+  "mdi:rfid",
+  "mdi:numeric-1-box",
+  "mdi:close",
+  "mdi:numeric-2-box",
+  "mdi:lightbulb-on",
+  "mdi:cog",
+
+  // boxicons
+  "bx:menu",
+];
+
+const IconPreloader = () => {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        width: 0,
+        height: 0,
+        overflow: "hidden",
+        pointerEvents: "none",
+      }}
+      aria-hidden="true"
+    >
+      {preloadIcons.map((name) => (
+        <Icon key={name} icon={name} />
+      ))}
+    </div>
+  );
+};
+
+// Gatsby Browser API: wrapRootElement
+// Inject a lightweight preloader so icons are requested immediately on app start.
+export const wrapRootElement = ({ element }) => {
+  return (
+    <>
+      <IconPreloader />
+      {element}
+    </>
+  );
+};

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,0 +1,51 @@
+import React from "react";
+import { Icon } from "@iconify/react";
+
+const preloadIcons = [
+  // ant-design
+  "ant-design:caret-left-outlined",
+  "ant-design:caret-right-outlined",
+
+  // logos
+  "logos:youtube-icon",
+
+  // akar-icons
+  "akar-icons:triangle-fill",
+  "akar-icons:calendar",
+  "akar-icons:more-vertical-fill",
+  "akar-icons:cross",
+
+  // mdi
+  "mdi:rfid",
+  "mdi:numeric-1-box",
+  "mdi:close",
+  "mdi:numeric-2-box",
+  "mdi:lightbulb-on",
+  "mdi:cog",
+
+  // boxicons
+  "bx:menu",
+
+  // uil (used in navbar)
+  "uil:home",
+  "uil:calender",
+  "uil:image",
+];
+
+const IconPreloader = () => (
+  <div
+    style={{ position: "absolute", width: 0, height: 0, overflow: "hidden", pointerEvents: "none" }}
+    aria-hidden="true"
+  >
+    {preloadIcons.map((name) => (
+      <Icon key={name} icon={name} />
+    ))}
+  </div>
+);
+
+export const wrapRootElement = ({ element }) => (
+  <>
+    <IconPreloader />
+    {element}
+  </>
+);

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -7,6 +7,8 @@ const AppHeader = (props) => {
     <Helmet>
       <title>{title}</title>
       <link rel="icon" href={icon} />
+      <link rel="preconnect" href="https://api.iconify.design" crossOrigin="anonymous" />
+      <link rel="dns-prefetch" href="https://api.iconify.design" />
     </Helmet>
   );
 };


### PR DESCRIPTION
已實作全站 Iconify 載入優化，降低首次繪製延遲問題，影響範圍為所有頁面。

變更摘要
- 新增全域預載入機制（Gatsby Browser + SSR）
  - 在 [gatsby-browser.js](gatsby-browser.js) 注入一個隱形的 Icon 預載入器，於應用初始化即向 Iconify 取得各頁常用圖示，縮短元件實際渲染時的等待。
  - 新增 [gatsby-ssr.js](gatsby-ssr.js)，在 SSR 階段即將預載入器包含於初始 HTML，確保首屏 hydration 後立即觸發圖示請求，改善首屏顯示延遲。
  - 預載入集合涵蓋 ant-design、logos、akar-icons、mdi、bx、uil，對應程式中實際使用到的 icon。

- 加快與 Iconify CDN 的連線建立
  - 在 [src/components/header.js](src/components/header.js) 加入 preconnect 與 dns-prefetch 至 https://api.iconify.design，降低 DNS/TLS 往返延遲。

此方案的效益
- 適用於全站所有頁面（透過 Gatsby 的 wrapRootElement 全域注入）；
- 加速圖示資料的首次取得時間，減少 Icon 遲滯與跳動；
- 無需更動既有頁面中的 Icon 使用方式（維持以字串 "prefix:name" 使用）。

後續可選強化（可進一步將首屏延遲降至趨近 0）
- 離線/打包圖示：將常用圖示以離線資料方式打包（例如安裝對應的 @iconify/icons-mdi、@iconify/icons-ant-design、@iconify/icons-logos、@iconify/icons-bx、@iconify/icons-uil 套件，改為以物件匯入 icon 傳入 Icon 組件），即可完全移除對 CDN 的執行階段請求，達成即時顯示與更穩定的首屏體驗。
- 若後續新增新的圖示，只要把名稱加入上述兩支檔案中的預載入列表即可一併加速。
