### PR TITLE
修正 Prettier 忽略 Codex 技能檔

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 /public
 /.cache
+/.codex


### PR DESCRIPTION
## 變更內容

- 在 `.prettierignore` 加入 `/.codex`
- 避免專案內的 Codex 技能文件被網站程式碼格式檢查納入

## 原因

Prettier CI 會掃描 `.codex/skills/ui-ux-pro-max/SKILL.md`，造成與網站原始碼無關的格式檢查失敗。

## 影響

網站程式碼仍維持完整的 Prettier 檢查，僅排除 `.codex/` 工具設定目錄。

## 驗證

- `yarn prettier`
- `yarn exec prettier -- --check .`
- `git diff --check`