### PR TITLE
修正 小螢幕相簿分頁跑版

### DIFF
--- a/src/css/pagination.css
+++ b/src/css/pagination.css
@@ -35,7 +35,7 @@
 }
 
 .rc-pagination {
-  @apply flex flex-row flex-wrap justify-center items-center gap-2 text-lg;
+  @apply flex flex-row flex-nowrap justify-center items-center gap-2 text-lg;
 }
 
 .rc-pagination > li {
@@ -48,6 +48,10 @@
 
 .rc-pagination > .rc-pagination-disabled {
   @apply cursor-not-allowed opacity-35;
+}
+
+.rc-pagination-simple > .rc-pagination-options {
+  @apply hidden;
 }
 
 .rc-pagination a,

--- a/src/pages/gallery_list.js
+++ b/src/pages/gallery_list.js
@@ -10,6 +10,7 @@ import chevronLeft from "@iconify/icons-akar-icons/chevron-left";
 import chevronRight from "@iconify/icons-akar-icons/chevron-right";
 import moreHorizontal from "@iconify/icons-akar-icons/more-horizontal";
 import Pagination from "rc-pagination";
+import { useMediaQuery } from "react-responsive";
 import "../css/pagination.css";
 import ImageWithPlaceholder from "../components/image-with-placeholder";
 import useGoogleAdsConversion from "../hooks/useGoogleAdsConversion";
@@ -17,6 +18,7 @@ import useGoogleAdsConversion from "../hooks/useGoogleAdsConversion";
 const GalleryList = ({ data }) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [searchQuery, setSearchQuery] = useState("");
+  const isSmallDevice = useMediaQuery({ maxWidth: 639 });
 
   // Google Ads 轉換追蹤
   useGoogleAdsConversion();
@@ -107,6 +109,7 @@ const GalleryList = ({ data }) => {
                 total={itemCount}
                 pageSize={perPage}
                 showTitle={false}
+                simple={isSmallDevice ? { readOnly: true } : false}
                 prevIcon={
                   <Icon icon={chevronLeft} width="24" aria-hidden="true" />
                 }
@@ -148,6 +151,7 @@ const GalleryList = ({ data }) => {
                 total={itemCount}
                 pageSize={perPage}
                 showTitle={false}
+                simple={isSmallDevice ? { readOnly: true } : false}
                 prevIcon={
                   <Icon icon={chevronLeft} width="24" aria-hidden="true" />
                 }


### PR DESCRIPTION
## 變更內容

- 小於 640px 時改用精簡分頁，避免頁碼換行跑版
- 隱藏精簡模式產生的空白 options 項目，讓箭頭與頁碼真正置中
- 分頁列禁止換行

## 問題原因

完整頁碼在小螢幕寬度不足時會換行；切換精簡模式後，`rc-pagination` 仍輸出一個空白 options 項目並套用最小寬度，導致可見內容向左偏移。

## 驗證

- `yarn prettier`
- `HOME=/tmp yarn build`
